### PR TITLE
dev-libs/libffi: fix a typo in libffi-3.2.1-riscv-r20171227.patch

### DIFF
--- a/dev-libs/libffi/files/libffi-3.2.1-riscv-r20171227.patch
+++ b/dev-libs/libffi/files/libffi-3.2.1-riscv-r20171227.patch
@@ -1449,7 +1449,7 @@ index 000000000000..986509b7df87
 +   #elif __riscv_float_abi_single
 +    FFI_DEFAULT_ABI = FFI_RV32_SINGLE
 +   #else
-+    FFI_DEFAULT_ABI - FFI_RV32_DOUBLE
++    FFI_DEFAULT_ABI = FFI_RV32_DOUBLE
 +//  #else
 +//    FFI_DEFAULT_ABI = FFI_RV32
 +  #endif


### PR DESCRIPTION
Instead of assigning FFI_RV32_DOUBLE to FFI_DEFAULT_ABI, the current
code subtracts it. Fix it by s/-/=/.