### PR TITLE
sys-libs/glibc: let default for src_prepare apply the patches

### DIFF
--- a/sys-libs/glibc/glibc-2.27_pre3.ebuild
+++ b/sys-libs/glibc/glibc-2.27_pre3.ebuild
@@ -203,6 +203,8 @@ pkg_pretend() {
 }
 
 src_prepare() {
+	local PATCHES=( "${FILESDIR}/${P}.patch" )
+
 	if just_headers ; then
 		if [[ -e ports/sysdeps/mips/preconfigure ]] ; then
 			# mips peeps like to screw with us.  if building headers,
@@ -241,8 +243,6 @@ src_prepare() {
 				debug/Makefile || die
 		fi
 	fi
-
-	epatch "${FILESDIR}/${P}.patch"
 }
 
 glibc_do_configure() {


### PR DESCRIPTION
Remove the use of epatch to apply patches. In EAPI6, the default
behavior for src_prepare is to apply all the patches (defined in -p1
format) in the PATCHES bash array automatically.

Note that this changes the order in which patches are applied with
respect to user-supplied patches and actually corrects the
order. Previously, the epatch statement appeared after the call to
default, which applies the user-provided patches internally. This may
cause the later epatch statement to fail if it doesn't apply cleanly.

Package-Manager: Portage-2.3.24, Repoman-2.3.6
RepoMan-Options: --force